### PR TITLE
Pretty print into EDN file

### DIFF
--- a/src/ordnungsamt/core.clj
+++ b/src/ordnungsamt/core.clj
@@ -1,6 +1,7 @@
 (ns ordnungsamt.core
   (:require [clojure.java.io :as io]
             [clojure.java.shell :refer [sh]]
+            [clojure.pprint :refer [pprint]]
             clojure.set
             [clojure.string :as string]
             [common-github.changeset :as changeset]
@@ -59,6 +60,8 @@
   (let [applied-migrations-filepath (str dir "/" applied-migrations-file)]
     (->> {:id id :_title title}
          (conj (read-registered-migrations dir))
+         pprint
+         with-out-str
          (spit applied-migrations-filepath))))
 
 (defn- files-to-commit [dir]


### PR DESCRIPTION
## Context

- GitHub shows a red symbol, with the warning "No newline at end of file" in the tooltip if there is no new line at the end of the file ([example](https://github.com/nubank/model-server/pull/173/files#diff-705ed03d699f19219b853c726d2928f37c4d333853c6899b2857a675f5b3e1c2))
  - This was mentioned [here](https://nubank.slack.com/archives/C027S2Y9P/p1617805051401100?thread_ts=1617796243.383100&cid=C027S2Y9P).
- If the list of migrations is too large, the contents in the EDN file will be in only one line

## Proposed changes

Pretty print the output in the EDN file.

Example:

The current code

```clojure
user=> (->> [{:id 1 :_title "This is a very long title. This is a very long title."} {:id 2 :_title "A short title"}]
            (spit "foo.edn"))
nil
```

creates the file

```bash
$ cat foo.edn
[{:id 1, :_title "This is a very long title. This is a very long title."} {:id 2, :_title "A short title"}]
```

(and no newline at the end of the file)

And the proposed modification

```clojure
user=> (->> [{:id 1 :_title "This is a very long title. This is a very long title."} {:id 2 :_title "A short title"}]
            pprint
            with-out-str
            (spit "foo.edn"))
nil
```

creates the file

```bash
$ cat foo.edn
[{:id 1,
  :_title "This is a very long title. This is a very long title."}
 {:id 2, :_title "A short title"}]
```

(and a newline at the end of the file)