### PR TITLE
git add --force files

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@ default_branch=$3
 service_directory=$4
 migrations_directory=$5
 
-clojure -m ordnungsamt.core "$org" "$service" "$default_branch" "$service_directory" "$migrations_directory"
+clojure --report stderr -m ordnungsamt.core "$org" "$service" "$default_branch" "$service_directory" "$migrations_directory"

--- a/src/ordnungsamt/core.clj
+++ b/src/ordnungsamt/core.clj
@@ -74,7 +74,7 @@
   (sh "git" "stash" "drop" :dir dir))
 
 (defn- local-commit! [title {:keys [modified deleted added]} dir]
-  (run! (fn [file] (utils/sh! "git" "add" file :dir dir))
+  (run! (fn [file] (utils/sh! "git" "add" "-f" file :dir dir))
         (concat modified added))
   (run! (fn [file] (utils/sh! "git" "rm" file :dir dir))
         deleted)


### PR DESCRIPTION
Prevent `ordnungsamt` from failing due to files changed in a migration that belongs to the `.gitignore` file.

I understand the migration knows what it's doing, then it might happen that projects are in a state that isn't expected.

This fix will prevent failures like these from happening:
- [dante](https://dashboard.nu.workflows.dev/repositories/nubank/dante/workflows/auto-refactor.yaml/runs/6cee778f-0e70-45e0-87da-85eb75bbfe4e?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [city-executor](https://dashboard.nu.workflows.dev/repositories/nubank/city-executor/workflows/auto-refactor.yaml/runs/8a6fb6fc-d38b-47bf-aa77-64b51fbf11b3?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [nest](https://dashboard.nu.workflows.dev/repositories/nubank/nest/workflows/auto-refactor.yaml/runs/2428a202-a02e-4e9b-a2a3-cf3a125b82f4?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [yamato](https://dashboard.nu.workflows.dev/repositories/nubank/yamato/workflows/auto-refactor.yaml/runs/5612dd50-3470-443c-aaae-19a2a1f25121?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [royale](https://dashboard.nu.workflows.dev/repositories/nubank/royale/workflows/auto-refactor.yaml/runs/306c634b-b2f3-4e93-b90e-69ad19ba872a?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [euphoria](https://dashboard.nu.workflows.dev/repositories/nubank/euphoria/workflows/auto-refactor.yaml/runs/1785588e-e9de-494a-8279-0183928056c2?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [joao-carter](https://dashboard.nu.workflows.dev/repositories/nubank/joao-carter/workflows/auto-refactor.yaml/runs/4b8be760-a324-465a-9f88-c7a07600729f?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)
- [zoop](https://dashboard.nu.workflows.dev/repositories/nubank/zoop-client/workflows/auto-refactor.yaml/runs/5d350d37-c240-42aa-8335-8c7f5f6933f3?cluster=cicd00-green&task=auto-refactor&step=service-refactor&view=logs)